### PR TITLE
[#19] Update Slacker library version

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,10 +1,10 @@
 (set-env!
   :source-paths #{"src"}
   :dependencies '[[adzerk/boot-test "1.0.4" :scope "test"]
+                  [emiln/slacker "1.2.0"]
                   [org.clojure/clojure "1.7.0-RC1"]
                   [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                   [org.clojure/data.json "0.2.5"]
-                  [emiln/slacker "1.2.0"]
                   [stylefruits/gniazdo "0.3.1"]])
 
 (deftask build

--- a/build.boot
+++ b/build.boot
@@ -1,19 +1,10 @@
 (set-env!
   :source-paths #{"src"}
-  :dependencies '[[expectations "2.0.9"]
+  :dependencies '[[adzerk/boot-test "1.0.4" :scope "test"]
                   [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                   [org.clojure/data.json "0.2.5"]
-                  [http-kit "2.1.16"]
-                  [slacker "0.1.0"]
+                  [emiln/slacker "1.2.0"]
                   [stylefruits/gniazdo "0.3.1"]])
-
-(require '[expectations :as exp])
-
-(deftask expectations
-  "Run tests"
-  []
-  (set-env! :source-paths #(conj % "test"))
-  (use 'logic-test))
 
 (deftask build
   "Builds an uberjar of this project that can be run with java -jar"
@@ -24,3 +15,10 @@
         :version "0.1.0")
    (uber)
    (jar :main 'stalmanu.run)))
+
+(deftask stalmanu-test
+  "Run the unit tests for Stalmanu in a pod."
+  []
+  (merge-env! :source-paths #{"test"})
+  (require 'adzerk.boot-test)
+  ((resolve 'adzerk.boot-test/test)))

--- a/build.boot
+++ b/build.boot
@@ -1,6 +1,7 @@
 (set-env!
   :source-paths #{"src"}
   :dependencies '[[adzerk/boot-test "1.0.4" :scope "test"]
+                  [org.clojure/clojure "1.7.0-RC1"]
                   [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                   [org.clojure/data.json "0.2.5"]
                   [emiln/slacker "1.2.0"]

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,24 @@
+## Customize the test machine
+machine:
+
+  # Pin the Boot and Clojure version
+  environment:
+    BOOT_CLOJURE_VERSION: 1.6.0
+    BOOT_VERSION: 2.0.0-rc14
+    JAVA_OPTS: -XXMaxPermSize=256m
+
+## Download and install Boot
+dependencies:
+  pre:
+    - wget -O boot "https://github.com/boot-clj/boot/releases/download/${BOOT_VERSION}/boot.sh"
+    - chmod a+x boot
+    - mv boot /home/ubuntu/bin
+  override:
+    - boot checkout
+  cache_directories:
+    - "~/.m2"
+
+## Run the Slacker tests
+test:
+  override:
+    - "boot stalmanu-test"

--- a/src/stalmanu/run.clj
+++ b/src/stalmanu/run.clj
@@ -1,7 +1,8 @@
 (ns stalmanu.run
   (:gen-class)
   (:require
-    [clojure.core.async :refer [<!! chan]]
+    [clojure.core.async :refer [<!! timeout]]
+    [clojure.tools.logging :refer [info]]
     [slacker.client :refer [handle emit!]]
     [stalmanu.logic :refer [interject?]]
     [stalmanu.rants :refer [full light]]))
@@ -25,4 +26,6 @@
   (handle :message interject!)
   (println "Connecting with token" token)
   (emit! :slacker.client/connect-bot token)
-  (<!! (chan)))
+  (loop []
+    (<!! (timeout 1000))
+    (recur)))

--- a/src/stalmanu/run.clj
+++ b/src/stalmanu/run.clj
@@ -27,5 +27,5 @@
   (println "Connecting with token" token)
   (emit! :slacker.client/connect-bot token)
   (loop []
-    (<!! (timeout 1000))
+    (<!! (timeout 10000))
     (recur)))

--- a/test/logic_test.clj
+++ b/test/logic_test.clj
@@ -1,18 +1,15 @@
 (ns logic-test
-  (:require [expectations   :refer [expect]]
+  (:require [clojure.test :refer [are deftest is testing]]
             [stalmanu.logic :refer [interject?]]))
 
-;; Ensure that only appropriate and educational notices about GNU plus Linux
-;; make it onto our channels.
-(expect false
-  (interject? "You should be allowed to say GNU/Linux"))
-(expect false
-  (interject? "And definitely also GNU+Linux"))
-(expect false
-  (interject? "Hell, even GNU and Linux should be fine."))
-(expect false
-  (interject? "More creative phrases like 'gnu-infested linux' should work."))
-(expect false
-  (interject? "Mentioning the Linux kernel should also be dandy."))
-(expect false
-  (interject? "As far as kernels go, Linux is pretty good."))
+(deftest about-interjections
+  (testing "Facts about injections"
+    (testing "only appropriate and educational notices about GNU plus Linux make
+             it onto our channels."
+      (are [text] (false? (interject? text))
+        "You should be allowed to say GNU/Linux"
+        "And definitely also GNU+Linux"
+        "Hell, even GNU and Linux should be fine."
+        "More creative phrases like 'gnu-infested linux' should work."
+        "Mentioning the Linux kernel should also be dandy."
+        "As far as kernels go, Linux is pretty good."))))


### PR DESCRIPTION
This overhaul brings Stalmanu up to date with the development that has happened to Slacker.

Merging this closes #19.
